### PR TITLE
fix: set up coordinators before forwarding platforms (stops setup-error log flood)

### DIFF
--- a/custom_components/wetter_alarm/__init__.py
+++ b/custom_components/wetter_alarm/__init__.py
@@ -8,11 +8,12 @@ https://github.com/redlukas/wetter-alarm
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from venv import logger
 
 from homeassistant.const import Platform
 from homeassistant.loader import async_get_loaded_integration
 
+from .const import CONFIG_DATA_LANGUAGE, CONFIG_POIS, LOGGER
+from .coordinator import WetterAlarmCoordinator
 from .data import WetterAlarmData
 
 if TYPE_CHECKING:
@@ -31,14 +32,31 @@ async def async_setup_entry(
     entry: WetterAlarmConfigEntry,
 ) -> bool:
     """Set up this integration using UI."""
-    logger.debug("Setting up entry %s", entry.entry_id)
-    logger.debug(entry.data)
+    LOGGER.debug("Setting up entry %s", entry.entry_id)
+
+    data_language = entry.data[CONFIG_DATA_LANGUAGE]
+    coordinators: list[WetterAlarmCoordinator] = []
+    for poi_name, poi_id in entry.data[CONFIG_POIS]:
+        coordinator = WetterAlarmCoordinator(
+            hass=hass,
+            logger=LOGGER,
+            poi_id=poi_id,
+            poi_name=poi_name,
+            data_language=data_language,
+        )
+        # Perform the initial poll here in the integration setup, *before*
+        # forwarding to the platforms. A transient failure then raises
+        # ConfigEntryNotReady so HA retries the entry with backoff, instead of
+        # the error escaping the forwarded sensor platform (which spams the log
+        # and can stall startup).
+        await coordinator.async_config_entry_first_refresh()
+        coordinators.append(coordinator)
 
     entry.runtime_data = WetterAlarmData(
         integration=async_get_loaded_integration(hass, entry.domain),
+        coordinators=coordinators,
     )
 
-    # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
@@ -58,5 +76,4 @@ async def async_reload_entry(
     entry: WetterAlarmConfigEntry,
 ) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/wetter_alarm/api.py
+++ b/custom_components/wetter_alarm/api.py
@@ -59,7 +59,7 @@ class WetterAlarmApiClient:
         try:
             res = await self._api_wrapper("get", alert_url)
 
-            meteo_alarms = res.get("meteo_alarms")
+            meteo_alarms = (res or {}).get("meteo_alarms") or []
 
             found_alarm = False
             for alarm in meteo_alarms:

--- a/custom_components/wetter_alarm/data.py
+++ b/custom_components/wetter_alarm/data.py
@@ -9,12 +9,15 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.loader import Integration
 
+    from .coordinator import WetterAlarmCoordinator
+
 
 type WetterAlarmConfigEntry = ConfigEntry[WetterAlarmData]
 
 
 @dataclass
 class WetterAlarmData:
-    """Data for the Blueprint integration."""
+    """Data for the wetter_alarm integration."""
 
     integration: Integration
+    coordinators: list[WetterAlarmCoordinator]

--- a/custom_components/wetter_alarm/sensor.py
+++ b/custom_components/wetter_alarm/sensor.py
@@ -14,8 +14,6 @@ from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 
 from custom_components.wetter_alarm.const import (
     ALARM_ID,
-    CONFIG_DATA_LANGUAGE,
-    CONFIG_POIS,
     DOMAIN,
     HINT,
     PRIORITY,
@@ -52,18 +50,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
-    pois_from_config = config_entry.data[CONFIG_POIS]
-    data_language = config_entry.data[CONFIG_DATA_LANGUAGE]
     all_sensors = []
-    for poi_name, poi_id in pois_from_config:
-        coordinator = WetterAlarmCoordinator(
-            hass=hass,
-            logger=_LOGGER,
-            poi_name=poi_name,
-            poi_id=poi_id,
-            data_language=data_language,
-        )
-
+    for coordinator in config_entry.runtime_data.coordinators:
         sensors = [
             WetterAlarmIdSensor(
                 coordinator, SensorEntityDescription(key=ALARM_ID, name="Alarm ID")
@@ -92,8 +80,6 @@ async def async_setup_entry(
         ]
 
         all_sensors.extend(sensors)
-
-        await coordinator.async_config_entry_first_refresh()
 
     async_add_entities(all_sensors)
 


### PR DESCRIPTION
## Problem

Setting up — and especially **reconfiguring** — the integration floods the log
~100×/sec with:

> `wetter_alarm raises exception ConfigEntryError in forwarded platform sensor; Instead raise ConfigEntryError before calling async_forward_entry_setups`

This pegs a CPU core, blocks the event loop, and can leave the **whole** Home
Assistant instance unreachable (the frontend hangs) — not just this integration.

### How to reproduce

Add the integration, then use **Reconfigure** (e.g. to rename the POI). The
reload that follows sends the integration into the error loop above.

### Root cause

1. `sensor.py::async_setup_entry` creates the `DataUpdateCoordinator` and calls
   `await coordinator.async_config_entry_first_refresh()` **inside the forwarded
   platform setup**. When the first poll doesn't succeed, the readiness/error
   exception escapes the forwarded platform — exactly what the log line warns
   about.
2. `async_reload_entry` reloads by calling `async_unload_entry` +
   `async_setup_entry` **manually**, bypassing the config-entries manager. That
   re-registers the update listener on every pass (the `async_on_unload` cleanup
   only runs on a real manager unload → listener leak) and re-runs the
   first-refresh outside a proper `SETUP_IN_PROGRESS` context. A Reconfigure —
   which both fires the update listener *and* calls `async_reload` — compounds
   this into the flood.

Two more latent issues fixed alongside:

- `__init__.py` imported the logger via `from venv import logger` (wrong module).
- `api.py::async_search_for_alerts` did `for alarm in res.get("meteo_alarms")`,
  which raises `TypeError` if the key is missing/`None`.

## Fix

- Create the coordinator(s) and run `async_config_entry_first_refresh()` in
  `__init__.py::async_setup_entry`, **before** `async_forward_entry_setups`, and
  store them on `entry.runtime_data`. A transient failure now raises
  `ConfigEntryNotReady`, so HA retries the entry with backoff (the documented
  pattern) instead of looping.
- `async_reload_entry` delegates to `hass.config_entries.async_reload`, so
  reloads go through the manager (proper teardown, no leaked listeners,
  first-refresh only during real setup).
- `sensor.py` reads the ready coordinators from `entry.runtime_data`.
- Use the integration `LOGGER` from `const.py` instead of `from venv import logger`.
- Guard `meteo_alarms` against `None`.

Unique IDs are POI-id based and unchanged → no entities are duplicated.

## Testing

Verified against a live POI: clean initial setup, all 8 sensors populate, and
the log flood is gone. (`data.py` uses the PEP 695 `type` alias → Python 3.12+.)
